### PR TITLE
Fix marshalling error when a machine has LVM volume groups

### DIFF
--- a/entity/machine.go
+++ b/entity/machine.go
@@ -28,7 +28,7 @@ type Machine struct {
 	IPAddresses                  []net.IP            `json:"ip_addresses,omitempty"`
 	BlockDeviceSet               []BlockDevice       `json:"blockdevice_set,omitempty"`
 	CacheSets                    []string            `json:"cache_sets,omitempty"`
-	VolumeGroups                 []string            `json:"volume_groups,omitempty"`
+	VolumeGroups                 []VolumeGroup       `json:"volume_groups,omitempty"`
 	InterfaceSet                 []NetworkInterface  `json:"interface_set,omitempty"`
 	BCaches                      []string            `json:"bcaches,omitempty"`
 	RAIDs                        []string            `json:"raids,omitempty"`

--- a/entity/volume_group.go
+++ b/entity/volume_group.go
@@ -9,6 +9,6 @@ type VolumeGroup struct {
     Size               int                    `json:"size,omitempty"`
     AvailableSize      int                    `json:"available_size,omitempty"`
     ID                 int                    `json:"id,omitempty"`
-	ResourceURI        string                 `json:"resource_uri,omitempty"`
+    ResourceURI        string                 `json:"resource_uri,omitempty"`
 }
 

--- a/entity/volume_group.go
+++ b/entity/volume_group.go
@@ -1,0 +1,14 @@
+package entity
+
+// VolumeGroup represents the MaaS volume-group endpoint.
+type VolumeGroup struct {
+    SystemID           string                 `json:"system_id,omitempty"`
+    UUID               string                 `json:"uuid,omitempty"`
+    UsedSize           int                    `json:"used_size,omitempty"`
+    Name               string                 `json:"name,omitempty"`
+    Size               int                    `json:"size,omitempty"`
+    AvailableSize      int                    `json:"available_size,omitempty"`
+    ID                 int                    `json:"id,omitempty"`
+	ResourceURI        string                 `json:"resource_uri,omitempty"`
+}
+

--- a/entity/volume_group.go
+++ b/entity/volume_group.go
@@ -1,14 +1,19 @@
 package entity
 
-// VolumeGroup represents the MaaS volume-group endpoint.
+// VolumeGroup represents the MaaS VolumeGroup endpoint.
 type VolumeGroup struct {
-    SystemID           string                 `json:"system_id,omitempty"`
-    UUID               string                 `json:"uuid,omitempty"`
-    UsedSize           int                    `json:"used_size,omitempty"`
-    Name               string                 `json:"name,omitempty"`
-    Size               int                    `json:"size,omitempty"`
-    AvailableSize      int                    `json:"available_size,omitempty"`
-    ID                 int                    `json:"id,omitempty"`
-    ResourceURI        string                 `json:"resource_uri,omitempty"`
+    HumanUsedSize      string                      `json:"human_used_size,omitempty"`
+    UUID               string                      `json:"uuid,omitempty"`
+    HumanAvailableSize string                      `json:"human_available_size,omitempty"`
+    SystemID           string                      `json:"system_id,omitempty"`
+    ID                 int                         `json:"id,omitempty"`
+    LogicalVolumes     interface{}                 `json:"logical_volumes,omitempty"`
+    Size               int                         `json:"size,omitempty"`
+    Devices            interface{}                 `json:"devices,omitempty"`
+    AvailableSize      int                         `json:"available_size,omitempty"`
+    UsedSize           int                         `json:"used_size,omitempty"`
+    HumanSize          string                      `json:"human_size,omitempty"`
+    Name               string                      `json:"name,omitempty"`
+    ResourceURI        string                      `json:"resource_uri,omitempty"`
 }
 

--- a/test/testdata/maas/machine.json
+++ b/test/testdata/maas/machine.json
@@ -450,3 +450,4 @@
     "cpu_speed": 0,
     "resource_uri": "/MAAS/api/2.0/machines/g8xyqs/"
 }
+

--- a/test/testdata/maas/machine.json
+++ b/test/testdata/maas/machine.json
@@ -174,14 +174,40 @@
     "owner": "user2",
     "status": 20,
     "volume_groups": [{
-      "system_id": "ccrfnk",
-      "uuid": "5b805aa2-3614-4b70-b99c-9c3ff65df4c3",
-      "used_size": 0,
-      "name": "my_volume_group-my_logical_volume",
-      "size": 4194304,
-      "available_size": 4194304,
-      "id": 2,
-      "resource_uri": "/MAAS/api/2.0/nodes/g8xyqs/blockdevices/2/"
+        "human_used_size": "0 bytes",
+        "uuid": "36f9585d-3ae0-429c-abb7-9d584bc6f941",
+        "human_available_size": "8.0 GB",
+        "system_id": "ccrfnk",
+        "id": 1,
+        "logical_volumes": [],
+        "size": 7990149120,
+        "devices": [
+            {
+                "uuid": "ecfa7d5b-bb76-4443-83ab-ad600c23b4de",
+                "size": 7994343424,
+                "bootable": false,
+                "tags": [],
+                "system_id": "ccrfnk",
+                "id": 2,
+                "used_for": "LVM volume for my_volume_group",
+                "type": "partition",
+                "path": "/dev/disk/by-dname/vda-part1",
+                "device_id": 1,
+                "filesystem": {
+                    "fstype": "lvm-pv",
+                    "label": null,
+                    "uuid": "cad18fde-2fc7-4aa5-a15b-739f88c3b671",
+                    "mount_point": null,
+                    "mount_options": null
+                },
+                "resource_uri": "/MAAS/api/2.0/nodes/ccrfnk/blockdevices/1/partition/2"
+            }
+        ],
+        "available_size": 7990149120,
+        "used_size": 0,
+        "human_size": "8.0 GB",
+        "name": "my_volume_group",
+        "resource_uri": "/MAAS/api/2.0/nodes/ccrfnk/volume-group/1/"
     }],
     "hwe_kernel": null,
     "netboot": true,

--- a/test/testdata/maas/machine.json
+++ b/test/testdata/maas/machine.json
@@ -173,7 +173,16 @@
     "storage_test_status_name": "Passed",
     "owner": "user2",
     "status": 20,
-    "volume_groups": [],
+    "volume_groups": [{
+      "system_id": "ccrfnk",
+      "uuid": "5b805aa2-3614-4b70-b99c-9c3ff65df4c3",
+      "used_size": 0,
+      "name": "my_volume_group-my_logical_volume",
+      "size": 4194304,
+      "available_size": 4194304,
+      "id": 2,
+      "resource_uri": "/MAAS/api/2.0/nodes/g8xyqs/blockdevices/2/"
+    }],
     "hwe_kernel": null,
     "netboot": true,
     "current_testing_result_id": 199,


### PR DESCRIPTION
When a machine is provisioned with LVM storage, an error is thrown:

```machine_test.go:15: json: cannot unmarshal object into Go struct field Machine.volume_groups of type string```

This is because `volume_groups` isn't an array of strings, it's an array of objects accroding to https://maas.io/docs/api

This PR adds a VolumeGroup type, and adds a `volume_group` array to the tests.